### PR TITLE
feat: add product-card-01 component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,7 @@ import {
   GridWidget,
   GridWidgetItem,
 } from "@/registry/new-york/components/grid-widget/grid-widget";
+import { ProductCard01 } from "@/registry/new-york/components/product-card-01/product-card-01";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
@@ -119,6 +120,22 @@ export default function Home() {
               </Card>
             </GridWidgetItem>
           </GridWidget>
+        </PreviewFrame>
+        {/* Product Card */}
+        <PreviewFrame
+          name="product-card-01"
+          title="Product Card"
+          registryType="component"
+        >
+          <div className="flex items-center justify-center min-h-[400px] relative">
+            <ProductCard01
+              title="Snickers Off-White 2024"
+              brand="NIKE"
+              price="$38.00"
+              image="https://placehold.co/400x300/ff4500/ffffff?text=Sneaker"
+              onAddToCart={() => console.log('Added to cart')}
+            />
+          </div>
         </PreviewFrame>
         {/* Booking Summary */}
         <PreviewFrame

--- a/registry.json
+++ b/registry.json
@@ -414,6 +414,28 @@
       "meta": {
         "screenshot": "/screenshots/grid-widget.png"
       }
+    },
+    {
+      "name": "product-card-01",
+      "type": "registry:component",
+      "title": "Product Card",
+      "description": "A product card usually for e-commerce website",
+      "dependencies": [
+        "@mui/material",
+        "@mui/icons-material",
+        "@emotion/react",
+        "@emotion/styled"
+      ],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "registry/new-york/components/product-card-01/product-card-01.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "screenshot": "/screenshots/product-card-01.png"
+      }
     }
   ]
 }

--- a/registry/new-york/components/product-card-01/product-card-01.tsx
+++ b/registry/new-york/components/product-card-01/product-card-01.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import * as React from "react";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardMedia from "@mui/material/CardMedia";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import AddIcon from "@mui/icons-material/Add";
+
+export interface ProductCard01Props {
+  title: string;
+  brand: string;
+  price: string;
+  image: string;
+  imageAlt?: string;
+  onAddToCart?: () => void;
+}
+
+export function ProductCard01({ 
+  title, 
+  brand, 
+  price, 
+  image, 
+  imageAlt = "",
+  onAddToCart 
+}: ProductCard01Props) {
+  return (
+    <Card sx={{ maxWidth: 320, borderRadius: 3, boxShadow: 2 }}>
+      <CardMedia
+        component="img"
+        height={240}
+        image={image}
+        alt={imageAlt || title}
+        sx={{ 
+          borderRadius: "12px 12px 0 0",
+          objectFit: "cover"
+        }}
+      />
+      <CardContent sx={{ p: 2.5 }}>
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", mb: 1 }}>
+          <Box sx={{ flexGrow: 1 }}>
+            <Typography 
+              variant="h6" 
+              component="h2" 
+              sx={{ 
+                fontWeight: 600, 
+                fontSize: "1.1rem",
+                mb: 0.5,
+                color: "text.primary"
+              }}
+            >
+              {title}
+            </Typography>
+            <Typography 
+              variant="body2" 
+              sx={{ 
+                color: "text.secondary",
+                textTransform: "uppercase",
+                fontSize: "0.75rem",
+                fontWeight: 500,
+                letterSpacing: 0.5,
+                mb: 1
+              }}
+            >
+              {brand}
+            </Typography>
+            <Typography 
+              variant="h6" 
+              sx={{ 
+                fontWeight: 700,
+                fontSize: "1.25rem",
+                color: "text.primary"
+              }}
+            >
+              {price}
+            </Typography>
+          </Box>
+          <IconButton
+            onClick={onAddToCart}
+            sx={{
+              bgcolor: "grey.900",
+              color: "common.white",
+              width: 40,
+              height: 40,
+              "&:hover": {
+                bgcolor: "grey.800"
+              },
+              ...theme => theme.applyStyles('dark', {
+                bgcolor: "grey.100",
+                color: "grey.900",
+                "&:hover": {
+                  bgcolor: "grey.200"
+                }
+              })
+            }}
+          >
+            <AddIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Implements product card component as requested in issue #2.

## Changes
- Created Material UI product card component matching provided design
- Added component to registry.json with proper metadata
- Created demo in app/page.tsx
- Supports dark mode and responsive design

Fixes #2

Generated with [Claude Code](https://claude.ai/code)